### PR TITLE
Resizable logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "@angular/platform-browser": "2.2.3",
     "@angular/platform-browser-dynamic": "2.2.3",
     "@angular/router": "3.2.3",
-    "angular2-resizable": "^0.4.1",
     "core-js": "^2.4.1",
     "ng2-dragula": "^1.2.2",
     "rxjs": "5.0.0-beta.12",

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,5 +1,4 @@
 import { Component } from '@angular/core';
-import { ResizeEvent } from 'angular2-resizable';
 
 import { AuthenticationService } from './services/authentication/authentication.service';
 import { StreamingService } from './services/streaming/streaming.service';

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -21,7 +21,6 @@ import { WatchlistComponent } from './watchlist/watchlist.component';
 import { ChartComponent } from './chart/chart.component';
 import { NewsComponent } from './news/news.component';
 import { PricePipe } from './price.pipe';
-import { ResizableDirective } from './resizable.directive';
 
 @NgModule({
   declarations: [
@@ -34,8 +33,7 @@ import { ResizableDirective } from './resizable.directive';
     WatchlistComponent,
     ChartComponent,
     NewsComponent,
-    PricePipe,
-    ResizableDirective
+    PricePipe
   ],
   imports: [
     BrowserModule,

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -2,7 +2,6 @@ import { BrowserModule } from '@angular/platform-browser';
 import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { HttpModule } from '@angular/http';
-import { ResizableModule } from 'angular2-resizable';
 import { DragulaModule } from 'ng2-dragula';
 
 import { AuthenticationService } from './services/authentication/authentication.service';
@@ -43,7 +42,6 @@ import { ResizableDirective } from './resizable.directive';
     DragulaModule,
     FormsModule,
     HttpModule,
-    ResizableModule
   ],
   providers: [
     AuthenticationService,

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -22,6 +22,7 @@ import { WatchlistComponent } from './watchlist/watchlist.component';
 import { ChartComponent } from './chart/chart.component';
 import { NewsComponent } from './news/news.component';
 import { PricePipe } from './price.pipe';
+import { ResizableDirective } from './resizable.directive';
 
 @NgModule({
   declarations: [
@@ -34,7 +35,8 @@ import { PricePipe } from './price.pipe';
     WatchlistComponent,
     ChartComponent,
     NewsComponent,
-    PricePipe
+    PricePipe,
+    ResizableDirective
   ],
   imports: [
     BrowserModule,

--- a/src/app/services/authentication/authentication.service.ts
+++ b/src/app/services/authentication/authentication.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 import { Http, Headers, RequestOptions } from '@angular/http';
 import { Subject } from 'rxjs/Subject';
+import 'rxjs/add/operator/map';
 
 @Injectable()
 export class AuthenticationService {

--- a/src/app/workspace-panel/workspace-panel.component.html
+++ b/src/app/workspace-panel/workspace-panel.component.html
@@ -7,8 +7,8 @@
   [style.minWidth.px]="minWidth"
   (mousedown)="setPanelActive()"
   >
-  <div class="resize-handle n" (mousedown)="resizeStart($event)" (mouseup)="resizeEnd($event)"></div>
-  <div class="resize-handle s" (mousedown)="resizeStart($event)" (mouseup)="resizeEnd($event)"></div>
+  <div class="resize-handle n" (mousedown)="resizeStart($event, 'n')" (mouseup)="resizeEnd($event)"></div>
+  <div class="resize-handle s" (mousedown)="resizeStart($event, 's')" (mouseup)="resizeEnd($event)"></div>
   <div
     class="workspace-item--header"
     draggable

--- a/src/app/workspace-panel/workspace-panel.component.html
+++ b/src/app/workspace-panel/workspace-panel.component.html
@@ -5,14 +5,10 @@
   [style.transform]="transform"
   [style.minHeight.px]="minHeight"
   [style.minWidth.px]="minWidth"
-  mwlResizable
   (mousedown)="setPanelActive()"
-  [validateResize]="validate"
-  [resizeEdges]="{bottom: true, right: true, top: true, left: true}"
-  [enableGhostResize]="true"
-  (resizeEnd)="onResizeEnd($event)"
-  (resizeStart)="onResizeStart($event)"
   >
+  <div class="resize-handle n" (mousedown)="resizeStart($event)" (mouseup)="resizeEnd($event)"></div>
+  <div class="resize-handle s" (mousedown)="resizeStart($event)" (mouseup)="resizeEnd($event)"></div>
   <div
     class="workspace-item--header"
     draggable

--- a/src/app/workspace-panel/workspace-panel.component.html
+++ b/src/app/workspace-panel/workspace-panel.component.html
@@ -12,6 +12,9 @@
   <div class="resize-handle e" (mousedown)="resizeStart($event, 'e')" (mouseup)="resizeEnd($event)"></div>
   <div class="resize-handle w" (mousedown)="resizeStart($event, 'w')" (mouseup)="resizeEnd($event)"></div>
   <div class="resize-handle nw" (mousedown)="resizeStart($event, 'nw')" (mouseup)="resizeEnd($event)"></div>
+  <div class="resize-handle ne" (mousedown)="resizeStart($event, 'ne')" (mouseup)="resizeEnd($event)"></div>
+  <div class="resize-handle sw" (mousedown)="resizeStart($event, 'sw')" (mouseup)="resizeEnd($event)"></div>
+  <div class="resize-handle se" (mousedown)="resizeStart($event, 'se')" (mouseup)="resizeEnd($event)"></div>
   <div
     class="workspace-item--header"
     draggable

--- a/src/app/workspace-panel/workspace-panel.component.html
+++ b/src/app/workspace-panel/workspace-panel.component.html
@@ -9,6 +9,8 @@
   >
   <div class="resize-handle n" (mousedown)="resizeStart($event, 'n')" (mouseup)="resizeEnd($event)"></div>
   <div class="resize-handle s" (mousedown)="resizeStart($event, 's')" (mouseup)="resizeEnd($event)"></div>
+  <div class="resize-handle e" (mousedown)="resizeStart($event, 'e')" (mouseup)="resizeEnd($event)"></div>
+  <div class="resize-handle w" (mousedown)="resizeStart($event, 'w')" (mouseup)="resizeEnd($event)"></div>
   <div
     class="workspace-item--header"
     draggable

--- a/src/app/workspace-panel/workspace-panel.component.html
+++ b/src/app/workspace-panel/workspace-panel.component.html
@@ -1,11 +1,11 @@
-<div class="resize-handle n" (mousedown)="resizeStart($event, null, 'n')" (mouseup)="resizeEnd($event)"></div>
-<div class="resize-handle s" (mousedown)="resizeStart($event, null, 's')" (mouseup)="resizeEnd($event)"></div>
-<div class="resize-handle e" (mousedown)="resizeStart($event, 'e', null)" (mouseup)="resizeEnd($event)"></div>
-<div class="resize-handle w" (mousedown)="resizeStart($event, 'w', null)" (mouseup)="resizeEnd($event)"></div>
-<div class="resize-handle nw" (mousedown)="resizeStart($event, 'w', 'n')" (mouseup)="resizeEnd($event)"></div>
-<div class="resize-handle ne" (mousedown)="resizeStart($event, 'e', 'n')" (mouseup)="resizeEnd($event)"></div>
-<div class="resize-handle sw" (mousedown)="resizeStart($event, 'w', 's')" (mouseup)="resizeEnd($event)"></div>
-<div class="resize-handle se" (mousedown)="resizeStart($event, 'e', 's')" (mouseup)="resizeEnd($event)"></div>
+<div class="resize-handle n" (mousedown)="resizeStart($event, null, 'n')" (mouseup)="resizeEnd()"></div>
+<div class="resize-handle s" (mousedown)="resizeStart($event, null, 's')" (mouseup)="resizeEnd()"></div>
+<div class="resize-handle e" (mousedown)="resizeStart($event, 'e', null)" (mouseup)="resizeEnd()"></div>
+<div class="resize-handle w" (mousedown)="resizeStart($event, 'w', null)" (mouseup)="resizeEnd()"></div>
+<div class="resize-handle nw" (mousedown)="resizeStart($event, 'w', 'n')" (mouseup)="resizeEnd()"></div>
+<div class="resize-handle ne" (mousedown)="resizeStart($event, 'e', 'n')" (mouseup)="resizeEnd()"></div>
+<div class="resize-handle sw" (mousedown)="resizeStart($event, 'w', 's')" (mouseup)="resizeEnd()"></div>
+<div class="resize-handle se" (mousedown)="resizeStart($event, 'e', 's')" (mouseup)="resizeEnd()"></div>
 <div
   class="workspace-item--header"
   draggable

--- a/src/app/workspace-panel/workspace-panel.component.html
+++ b/src/app/workspace-panel/workspace-panel.component.html
@@ -1,51 +1,41 @@
+<div class="resize-handle n" (mousedown)="resizeStart($event, 'n')" (mouseup)="resizeEnd($event)"></div>
+<div class="resize-handle s" (mousedown)="resizeStart($event, 's')" (mouseup)="resizeEnd($event)"></div>
+<div class="resize-handle e" (mousedown)="resizeStart($event, 'e')" (mouseup)="resizeEnd($event)"></div>
+<div class="resize-handle w" (mousedown)="resizeStart($event, 'w')" (mouseup)="resizeEnd($event)"></div>
+<div class="resize-handle nw" (mousedown)="resizeStart($event, 'nw')" (mouseup)="resizeEnd($event)"></div>
+<div class="resize-handle ne" (mousedown)="resizeStart($event, 'ne')" (mouseup)="resizeEnd($event)"></div>
+<div class="resize-handle sw" (mousedown)="resizeStart($event, 'sw')" (mouseup)="resizeEnd($event)"></div>
+<div class="resize-handle se" (mousedown)="resizeStart($event, 'se')" (mouseup)="resizeEnd($event)"></div>
 <div
-  class="workspace-item"
-  [ngStyle]="style"
-  [style.zIndex]="order"
-  [style.transform]="transform"
-  [style.minHeight.px]="minHeight"
-  [style.minWidth.px]="minWidth"
-  (mousedown)="setPanelActive()"
+  class="workspace-item--header"
+  draggable
+  (dragStartEvent)="onDragStart($event)"
+  (dragEvent)="onDrag($event)"
+  (dragEndEvent)="onDragEnd($event)"
   >
-  <div class="resize-handle n" (mousedown)="resizeStart($event, 'n')" (mouseup)="resizeEnd($event)"></div>
-  <div class="resize-handle s" (mousedown)="resizeStart($event, 's')" (mouseup)="resizeEnd($event)"></div>
-  <div class="resize-handle e" (mousedown)="resizeStart($event, 'e')" (mouseup)="resizeEnd($event)"></div>
-  <div class="resize-handle w" (mousedown)="resizeStart($event, 'w')" (mouseup)="resizeEnd($event)"></div>
-  <div class="resize-handle nw" (mousedown)="resizeStart($event, 'nw')" (mouseup)="resizeEnd($event)"></div>
-  <div class="resize-handle ne" (mousedown)="resizeStart($event, 'ne')" (mouseup)="resizeEnd($event)"></div>
-  <div class="resize-handle sw" (mousedown)="resizeStart($event, 'sw')" (mouseup)="resizeEnd($event)"></div>
-  <div class="resize-handle se" (mousedown)="resizeStart($event, 'se')" (mouseup)="resizeEnd($event)"></div>
   <div
-    class="workspace-item--header"
-    draggable
-    (dragStartEvent)="onDragStart($event)"
-    (dragEvent)="onDrag($event)"
-    (dragEndEvent)="onDragEnd($event)"
-    >
+    class="workspace-item--header-draggable-container"
+    [dragula]='"bag-one"'
+    [dragulaModel]="components"
+  >
     <div
-      class="workspace-item--header-draggable-container"
-      [dragula]='"bag-one"'
-      [dragulaModel]="components"
-    >
-      <div
-        class="workspace-item--header-draggable-item"
-        *ngFor="let component of components"
-        [ngClass]="{ 'active': component.id === activeComponentId }"
-        (click)="showComponent(component.id)"
-        [attr.data-component-id]="component.id"
-        [attr.data-panel-id]="panelId"
-        >
-        {{ component.header }}
-        <div class="workspace-item--header-draggable-item--destroy" (click)="destroyComponent(component.id, component.type)">
-          x
-        </div>
+      class="workspace-item--header-draggable-item"
+      *ngFor="let component of components"
+      [ngClass]="{ 'active': component.id === activeComponentId }"
+      (click)="showComponent(component.id)"
+      [attr.data-component-id]="component.id"
+      [attr.data-panel-id]="panelId"
+      >
+      {{ component.header }}
+      <div class="workspace-item--header-draggable-item--destroy" (click)="destroyComponent(component.id, component.type)">
+        x
       </div>
     </div>
-    <div class="workspace-item--destroy" (click)="destroyPanel()">
-      x
-    </div>
   </div>
-  <div class="workspace-item--content">
-    <div class="workspace-item--content-component" #dynamicComponentContainer></div>
+  <div class="workspace-item--destroy" (click)="destroyPanel()">
+    x
   </div>
+</div>
+<div class="workspace-item--content">
+  <div class="workspace-item--content-component" #dynamicComponentContainer></div>
 </div>

--- a/src/app/workspace-panel/workspace-panel.component.html
+++ b/src/app/workspace-panel/workspace-panel.component.html
@@ -11,6 +11,7 @@
   <div class="resize-handle s" (mousedown)="resizeStart($event, 's')" (mouseup)="resizeEnd($event)"></div>
   <div class="resize-handle e" (mousedown)="resizeStart($event, 'e')" (mouseup)="resizeEnd($event)"></div>
   <div class="resize-handle w" (mousedown)="resizeStart($event, 'w')" (mouseup)="resizeEnd($event)"></div>
+  <div class="resize-handle nw" (mousedown)="resizeStart($event, 'nw')" (mouseup)="resizeEnd($event)"></div>
   <div
     class="workspace-item--header"
     draggable

--- a/src/app/workspace-panel/workspace-panel.component.html
+++ b/src/app/workspace-panel/workspace-panel.component.html
@@ -1,11 +1,11 @@
-<div class="resize-handle n" (mousedown)="resizeStart($event, 'n')" (mouseup)="resizeEnd($event)"></div>
-<div class="resize-handle s" (mousedown)="resizeStart($event, 's')" (mouseup)="resizeEnd($event)"></div>
-<div class="resize-handle e" (mousedown)="resizeStart($event, 'e')" (mouseup)="resizeEnd($event)"></div>
-<div class="resize-handle w" (mousedown)="resizeStart($event, 'w')" (mouseup)="resizeEnd($event)"></div>
-<div class="resize-handle nw" (mousedown)="resizeStart($event, 'nw')" (mouseup)="resizeEnd($event)"></div>
-<div class="resize-handle ne" (mousedown)="resizeStart($event, 'ne')" (mouseup)="resizeEnd($event)"></div>
-<div class="resize-handle sw" (mousedown)="resizeStart($event, 'sw')" (mouseup)="resizeEnd($event)"></div>
-<div class="resize-handle se" (mousedown)="resizeStart($event, 'se')" (mouseup)="resizeEnd($event)"></div>
+<div class="resize-handle n" (mousedown)="resizeStart($event, null, 'n')" (mouseup)="resizeEnd($event)"></div>
+<div class="resize-handle s" (mousedown)="resizeStart($event, null, 's')" (mouseup)="resizeEnd($event)"></div>
+<div class="resize-handle e" (mousedown)="resizeStart($event, 'e', null)" (mouseup)="resizeEnd($event)"></div>
+<div class="resize-handle w" (mousedown)="resizeStart($event, 'w', null)" (mouseup)="resizeEnd($event)"></div>
+<div class="resize-handle nw" (mousedown)="resizeStart($event, 'w', 'n')" (mouseup)="resizeEnd($event)"></div>
+<div class="resize-handle ne" (mousedown)="resizeStart($event, 'e', 'n')" (mouseup)="resizeEnd($event)"></div>
+<div class="resize-handle sw" (mousedown)="resizeStart($event, 'w', 's')" (mouseup)="resizeEnd($event)"></div>
+<div class="resize-handle se" (mousedown)="resizeStart($event, 'e', 's')" (mouseup)="resizeEnd($event)"></div>
 <div
   class="workspace-item--header"
   draggable

--- a/src/app/workspace-panel/workspace-panel.component.scss
+++ b/src/app/workspace-panel/workspace-panel.component.scss
@@ -25,7 +25,7 @@
   &.e {
     height: 100%;
     width: 5px;
-    left: 100%;
+    right: 0;
 
     &:hover {
       cursor: e-resize;
@@ -48,6 +48,37 @@
 
     &:hover {
       cursor: se-resize;
+    }
+  }
+
+  &.ne {
+    height: 5px;
+    width: 5px;
+    right: 0;
+
+    &:hover {
+      cursor: sw-resize;
+    }
+  }
+
+  &.se {
+    height: 5px;
+    width: 5px;
+    bottom: 0;
+    right: 0;
+
+    &:hover {
+      cursor: nw-resize;
+    }
+  }
+
+  &.sw {
+    height: 5px;
+    width: 5px;
+    bottom: 0;
+
+    &:hover {
+      cursor: ne-resize;
     }
   }
 }

--- a/src/app/workspace-panel/workspace-panel.component.scss
+++ b/src/app/workspace-panel/workspace-panel.component.scss
@@ -83,8 +83,7 @@
   }
 }
 
-
-.workspace-item {
+:host {
   border: 1px #f5f5f5 solid;
   box-sizing: border-box;
   position: absolute;
@@ -95,47 +94,50 @@
   border: solid 1px #f5f5f5;
   font-family: Arial;
 
-  &--header {
-    height: 30px;
-    display: flex;
-    flex-direction: row;
-    border-bottom: solid 1px #eeeeee;
-    align-items: center;
+  .workspace-item {
 
-    &-draggable-container {
+    &--header {
+      height: 30px;
       display: flex;
-      overflow: hidden;
-      flex-grow: 1;
-    }
+      flex-direction: row;
+      border-bottom: solid 1px #eeeeee;
+      align-items: center;
 
-    &-draggable-item {
-
-      display: flex;
-      box-sizing: border-box;
-      color: #065ed0;
-
-      &.active {
-        color: #1a1a1a;
-        border-bottom: 1px black solid;
+      &-draggable-container {
+        display: flex;
+        overflow: hidden;
+        flex-grow: 1;
       }
 
-      &--destroy {
-        color: black;
-        margin: 0 10px 0 5px;
+      &-draggable-item {
+
+        display: flex;
+        box-sizing: border-box;
+        color: #065ed0;
+
+        &.active {
+          color: #1a1a1a;
+          border-bottom: 1px black solid;
+        }
+
+        &--destroy {
+          color: black;
+          margin: 0 10px 0 5px;
+        }
       }
     }
-  }
 
-  &--destroy {
-    cursor: pointer;
-    width: 10px;
-    margin-right: 10px;
-    margin-left: auto;
-    color: black;
-  }
+    &--destroy {
+      cursor: pointer;
+      width: 10px;
+      margin-right: 10px;
+      margin-left: auto;
+      color: black;
+    }
 
-  &--content {
-    flex: 1;
-    flex-flow: row wrap;
+    &--content {
+      flex: 1;
+      flex-flow: row wrap;
+    }
   }
 }

--- a/src/app/workspace-panel/workspace-panel.component.scss
+++ b/src/app/workspace-panel/workspace-panel.component.scss
@@ -1,3 +1,29 @@
+.resize-handle {
+  position: absolute;
+  background: black;
+
+  &.n {
+    height: 5px;
+    top: 0;
+    width: 100%;
+
+    &:hover {
+      cursor: n-resize;
+    }
+  }
+
+  &.s {
+    height: 5px;
+    bottom: 0;
+    width: 100%;
+
+    &:hover {
+      cursor: s-resize;
+    }
+  }
+}
+
+
 .workspace-item {
   border: 1px #f5f5f5 solid;
   box-sizing: border-box;

--- a/src/app/workspace-panel/workspace-panel.component.scss
+++ b/src/app/workspace-panel/workspace-panel.component.scss
@@ -41,6 +41,15 @@
       cursor: w-resize;
     }
   }
+
+  &.nw {
+    height: 5px;
+    width: 5px;
+
+    &:hover {
+      cursor: se-resize;
+    }
+  }
 }
 
 

--- a/src/app/workspace-panel/workspace-panel.component.scss
+++ b/src/app/workspace-panel/workspace-panel.component.scss
@@ -1,6 +1,6 @@
 .resize-handle {
   position: absolute;
-  background: black;
+  background: transparent;
 
   &.n {
     height: 5px;
@@ -8,7 +8,7 @@
     width: 100%;
 
     &:hover {
-      cursor: n-resize;
+      cursor: ns-resize;
     }
   }
 
@@ -18,7 +18,7 @@
     width: 100%;
 
     &:hover {
-      cursor: s-resize;
+      cursor: ns-resize;
     }
   }
 
@@ -28,7 +28,7 @@
     right: 0;
 
     &:hover {
-      cursor: e-resize;
+      cursor: ew-resize;
     }
   }
 
@@ -38,7 +38,7 @@
     left: 0;
 
     &:hover {
-      cursor: w-resize;
+      cursor: ew-resize;
     }
   }
 
@@ -47,7 +47,7 @@
     width: 5px;
 
     &:hover {
-      cursor: se-resize;
+      cursor: nwse-resize;
     }
   }
 
@@ -57,7 +57,7 @@
     right: 0;
 
     &:hover {
-      cursor: sw-resize;
+      cursor: nesw-resize;
     }
   }
 
@@ -68,7 +68,7 @@
     right: 0;
 
     &:hover {
-      cursor: nw-resize;
+      cursor: nwse-resize;
     }
   }
 
@@ -78,7 +78,7 @@
     bottom: 0;
 
     &:hover {
-      cursor: ne-resize;
+      cursor: nesw-resize;
     }
   }
 }
@@ -138,6 +138,7 @@
     &--content {
       flex: 1;
       flex-flow: row wrap;
+      overflow: scroll;
     }
   }
 }

--- a/src/app/workspace-panel/workspace-panel.component.scss
+++ b/src/app/workspace-panel/workspace-panel.component.scss
@@ -21,6 +21,26 @@
       cursor: s-resize;
     }
   }
+
+  &.e {
+    height: 100%;
+    width: 5px;
+    left: 100%;
+
+    &:hover {
+      cursor: e-resize;
+    }
+  }
+
+  &.w {
+    height: 100%;
+    width: 5px;
+    left: 0;
+
+    &:hover {
+      cursor: w-resize;
+    }
+  }
 }
 
 

--- a/src/app/workspace-panel/workspace-panel.component.ts
+++ b/src/app/workspace-panel/workspace-panel.component.ts
@@ -201,6 +201,7 @@ export class WorkspacePanelComponent implements OnInit {
 
     this.mouseMoveSub.unsubscribe();
     this.mouseUpSub.unsubscribe();
+    this.setStyleByPercentage(this.calculateRelativeStyle(this.pixelStyle));
     this.handlePanelChanged();
   }
 

--- a/src/app/workspace-panel/workspace-panel.component.ts
+++ b/src/app/workspace-panel/workspace-panel.component.ts
@@ -157,9 +157,9 @@ export class WorkspacePanelComponent implements OnInit {
         case 'n':
 
           resizeChange = {
-            height: Math.max(this.minHeight, initialStyle.height + yChange),
+            height: Math.max(this.minHeight, Math.min(initialStyle.height + yChange, initialStyle.height + initialStyle.top)),
             width: initialStyle.width,
-            top: initialStyle.top + (initialStyle.height + yChange <= this.minHeight ? (initialStyle.height - this.minHeight) : -yChange),
+            top: Math.max(0, initialStyle.top + (initialStyle.height + yChange <= this.minHeight ? (initialStyle.height - this.minHeight) : -yChange)),
             left: initialStyle.left,
           };
           break;
@@ -167,7 +167,7 @@ export class WorkspacePanelComponent implements OnInit {
         case 's':
 
           resizeChange = {
-            height: Math.max(this.minHeight, initialStyle.height - yChange),
+            height: Math.max(this.minHeight, Math.min(initialStyle.height - yChange, this.workspaceDimensions.height - initialStyle.top)),
             width: initialStyle.width,
             top: initialStyle.top,
             left: initialStyle.left,
@@ -178,7 +178,7 @@ export class WorkspacePanelComponent implements OnInit {
 
           resizeChange = {
             height: initialStyle.height,
-            width: Math.max(this.minWidth, initialStyle.width - xChange),
+            width: Math.max(this.minWidth, Math.min(initialStyle.width - xChange, this.workspaceDimensions.width - initialStyle.left)),
             top: initialStyle.top,
             left: initialStyle.left,
           };
@@ -188,28 +188,28 @@ export class WorkspacePanelComponent implements OnInit {
 
           resizeChange = {
             height: initialStyle.height,
-            width: Math.max(this.minWidth, initialStyle.width + xChange),
+            width: Math.max(this.minWidth, Math.min(initialStyle.width + xChange, initialStyle.width + initialStyle.left)),
             top: initialStyle.top,
-            left: initialStyle.left - (initialStyle.width + xChange <= this.minWidth ? (initialStyle.width - this.minWidth) * -1 : xChange),
+            left: Math.max(0, initialStyle.left - (initialStyle.width + xChange <= this.minWidth ? (initialStyle.width - this.minWidth) * -1 : xChange)),
           };
           break;
 
         case 'nw':
 
           resizeChange = {
-            height: Math.max(this.minHeight, initialStyle.height + yChange),
-            width: Math.max(this.minWidth, initialStyle.width - xChange),
-            top: initialStyle.top + (initialStyle.height + yChange <= this.minHeight ? (initialStyle.height - this.minHeight) : -yChange),
-            left: initialStyle.left - (initialStyle.width + xChange <= this.minWidth ? (initialStyle.width - this.minWidth) * -1 : xChange),
+            height: Math.max(this.minHeight, Math.min(initialStyle.height + yChange, initialStyle.height + initialStyle.top)),
+            width: Math.max(this.minWidth, Math.min(initialStyle.width + xChange, initialStyle.width + initialStyle.left)),
+            top: Math.max(0, initialStyle.top + (initialStyle.height + yChange <= this.minHeight ? (initialStyle.height - this.minHeight) : -yChange)),
+            left: Math.max(0, initialStyle.left - (initialStyle.width + xChange <= this.minWidth ? (initialStyle.width - this.minWidth) * -1 : xChange)),
           };
           break;
 
         case 'ne':
 
           resizeChange = {
-            height: Math.max(this.minHeight, initialStyle.height + yChange),
-            width: Math.max(this.minWidth, initialStyle.width - xChange),
-            top: initialStyle.top + (initialStyle.height + yChange <= this.minHeight ? (initialStyle.height - this.minHeight) : -yChange),
+            height: Math.max(this.minHeight, Math.min(initialStyle.height + yChange, initialStyle.height + initialStyle.top)),
+            width: Math.max(this.minWidth, Math.min(initialStyle.width - xChange, this.workspaceDimensions.width - initialStyle.left)),
+            top: Math.max(0, initialStyle.top + (initialStyle.height + yChange <= this.minHeight ? (initialStyle.height - this.minHeight) : -yChange)),
             left: initialStyle.left,
           };
           break;
@@ -217,8 +217,8 @@ export class WorkspacePanelComponent implements OnInit {
         case 'se':
 
           resizeChange = {
-            height: Math.max(this.minHeight, initialStyle.height - yChange),
-            width: Math.max(this.minWidth, initialStyle.width - xChange),
+            height: Math.max(this.minHeight, Math.min(initialStyle.height - yChange, this.workspaceDimensions.height - initialStyle.top)),
+            width: Math.max(this.minWidth, Math.min(initialStyle.width - xChange, this.workspaceDimensions.width - initialStyle.left)),
             left: initialStyle.left,
             top: initialStyle.top
           };
@@ -227,25 +227,30 @@ export class WorkspacePanelComponent implements OnInit {
         case 'sw':
 
           resizeChange = {
-            height: Math.max(this.minHeight, initialStyle.height - yChange),
-            width: Math.max(this.minWidth, initialStyle.width + xChange),
+            height: Math.max(this.minHeight, Math.min(initialStyle.height - yChange, this.workspaceDimensions.height - initialStyle.top)),
+            width: Math.max(this.minWidth, Math.min(initialStyle.width + xChange, initialStyle.width + initialStyle.left)),
             top: initialStyle.top,
-            left: initialStyle.left - (initialStyle.width + xChange <= this.minWidth ? (initialStyle.width - this.minWidth) * -1 : xChange)
+            left: Math.max(0, initialStyle.left - (initialStyle.width + xChange <= this.minWidth ? (initialStyle.width - this.minWidth) * -1 : xChange)),
           };
           break;
     }
 
-    if (
-      resizeChange.top < 0 ||
-      resizeChange.left < 0 ||
-      resizeChange.height < this.minHeight ||
-      resizeChange.height + resizeChange.top < 0 ||
-      resizeChange.height + resizeChange.top > this.workspaceDimensions.height ||
-      resizeChange.width + resizeChange.left > this.workspaceDimensions.width ||
-      resizeChange.width < this.minWidth
-    ) {
-      return false;
-    }
+    // resizeChange.height = Math.min(Math.max(resizeChange.height, this.minHeight), this.workspaceDimensions.height - resizeChange.top);
+    // resizeChange.width = Math.min(Math.max(resizeChange.width, this.minWidth), this.workspaceDimensions.width - resizeChange.left);
+    // resizeChange.top = Math.max(resizeChange.top, 0);
+    // resizeChange.left = Math.max(resizeChange.left, 0);
+
+    // if (
+    //   resizeChange.top < 0 ||
+    //   resizeChange.left < 0 ||
+    //   resizeChange.height < this.minHeight ||
+    //   resizeChange.height + resizeChange.top < 0 ||
+    //   resizeChange.height + resizeChange.top > this.workspaceDimensions.height ||
+    //   resizeChange.width + resizeChange.left > this.workspaceDimensions.width ||
+    //   resizeChange.width < this.minWidth
+    // ) {
+    //   return false;
+    // }
 
     this.setStyleByPixels(resizeChange);
   }

--- a/src/app/workspace-panel/workspace-panel.component.ts
+++ b/src/app/workspace-panel/workspace-panel.component.ts
@@ -197,7 +197,7 @@ export class WorkspacePanelComponent implements OnInit {
     this.setStyleByPixels(resizeChange);
   }
 
-  resizeEnd(event) {
+  resizeEnd() {
 
     this.mouseMoveSub.unsubscribe();
     this.mouseUpSub.unsubscribe();
@@ -313,7 +313,6 @@ export class WorkspacePanelComponent implements OnInit {
 
   private setStyleByPixels(style) {
 
-    console.log('setting style', style);
     this.pixelStyle = style;
     this.relativeStyle = this.calculateRelativeStyle(style);
 

--- a/src/app/workspace-panel/workspace-panel.component.ts
+++ b/src/app/workspace-panel/workspace-panel.component.ts
@@ -135,6 +135,7 @@ export class WorkspacePanelComponent implements OnInit {
 
   resizeStart($event, direction) {
 
+    $event.preventDefault();
     this.setStyleByPixels(this.pixelStyle);
     this.setPanelActive();
     let resizeStartCoords = {

--- a/src/app/workspace-panel/workspace-panel.component.ts
+++ b/src/app/workspace-panel/workspace-panel.component.ts
@@ -187,6 +187,7 @@ export class WorkspacePanelComponent implements OnInit {
           };
           break;
         case 's':
+
           resizeChange = {
             height: Math.max(this.minHeight, initialStyle.height - yChange),
             width: initialStyle.width,
@@ -196,6 +197,7 @@ export class WorkspacePanelComponent implements OnInit {
           break;
 
         case 'e':
+
           resizeChange = {
             height: initialStyle.height,
             width: Math.max(this.minWidth, initialStyle.width - xChange),
@@ -205,6 +207,7 @@ export class WorkspacePanelComponent implements OnInit {
           break;
 
         case 'w':
+
           resizeChange = {
             height: initialStyle.height,
             width: Math.max(this.minWidth, initialStyle.width + xChange),
@@ -212,7 +215,29 @@ export class WorkspacePanelComponent implements OnInit {
             left: initialStyle.left - (initialStyle.width + xChange <= this.minWidth ? (initialStyle.width - this.minWidth) * -1 : xChange),
           };
           break;
+        //
+        // case 'nw':
+        //   resizeChange = {
+        //     height: Math.max(this.minHeight, initialStyle.height + yChange),
+        //     width: Math.max(this.minWidth, initialStyle.width + xChange),
+        //     top: initialStyle.top + (initialStyle.height + yChange <= this.minHeight ? (initialStyle.height - this.minHeight) : -yChange),
+        //     left: initialStyle.left - (initialStyle.width + xChange <= this.minWidth ? (initialStyle.width - this.minWidth) * -1 : xChange),
+        //   }
+        //   break;
     }
+
+    if (
+      resizeChange.top < 0 ||
+      resizeChange.left < 0 ||
+      resizeChange.height < this.minHeight ||
+      resizeChange.height + resizeChange.top < 0 ||
+      resizeChange.height + resizeChange.top > this.workspaceDimensions.height ||
+      resizeChange.width + resizeChange.left > this.workspaceDimensions.width ||
+      resizeChange.width < this.minWidth
+    ) {
+      return false;
+    }
+
     this.setStyleByPixels(resizeChange);
   }
 

--- a/src/app/workspace-panel/workspace-panel.component.ts
+++ b/src/app/workspace-panel/workspace-panel.component.ts
@@ -31,7 +31,8 @@ import { Subscription } from 'rxjs/Subscription';
     '[style.top]': 'style.top',
     '[style.minHeight]': 'minHeight',
     '[style.minWidth]': 'minWidth',
-    '[style.transform]': 'transform'
+    '[style.transform]': 'transform',
+    '[style.zIndex]': 'order'
   }
 })
 export class WorkspacePanelComponent implements OnInit {
@@ -135,7 +136,7 @@ export class WorkspacePanelComponent implements OnInit {
   resizeStart($event, direction) {
 
     this.setStyleByPixels(this.pixelStyle);
-
+    this.setPanelActive();
     let resizeStartCoords = {
       x: $event.clientX,
       y: $event.clientY
@@ -234,23 +235,6 @@ export class WorkspacePanelComponent implements OnInit {
           };
           break;
     }
-
-    // resizeChange.height = Math.min(Math.max(resizeChange.height, this.minHeight), this.workspaceDimensions.height - resizeChange.top);
-    // resizeChange.width = Math.min(Math.max(resizeChange.width, this.minWidth), this.workspaceDimensions.width - resizeChange.left);
-    // resizeChange.top = Math.max(resizeChange.top, 0);
-    // resizeChange.left = Math.max(resizeChange.left, 0);
-
-    // if (
-    //   resizeChange.top < 0 ||
-    //   resizeChange.left < 0 ||
-    //   resizeChange.height < this.minHeight ||
-    //   resizeChange.height + resizeChange.top < 0 ||
-    //   resizeChange.height + resizeChange.top > this.workspaceDimensions.height ||
-    //   resizeChange.width + resizeChange.left > this.workspaceDimensions.width ||
-    //   resizeChange.width < this.minWidth
-    // ) {
-    //   return false;
-    // }
 
     this.setStyleByPixels(resizeChange);
   }

--- a/src/app/workspace-panel/workspace-panel.component.ts
+++ b/src/app/workspace-panel/workspace-panel.component.ts
@@ -133,7 +133,7 @@ export class WorkspacePanelComponent implements OnInit {
     this.draggingHeaderItem = false;
   }
 
-  resizeStart($event, direction) {
+  resizeStart($event, horizontalDirection, verticalDirection) {
 
     $event.preventDefault();
     this.setStyleByPixels(this.pixelStyle);
@@ -144,97 +144,54 @@ export class WorkspacePanelComponent implements OnInit {
     };
     let initialStyle = Object.assign({}, this.pixelStyle);
 
-    this.mouseMoveSub = this.mouseMoveObs.subscribe(resizeEvent => this.resize(direction, resizeEvent, resizeStartCoords, initialStyle));
+    this.mouseMoveSub = this.mouseMoveObs.subscribe(resizeEvent => this.resize(horizontalDirection, verticalDirection, resizeEvent, resizeStartCoords, initialStyle));
     this.mouseUpSub = this.mouseUpObs.subscribe(resizeEvent => this.resizeEnd(resizeEvent));
   }
 
-  resize(resizeDirection, event, resizeStartCoords, initialStyle) {
+  resize(horizontalDirection, verticalDirection, event, resizeStartCoords, initialStyle) {
 
-    let resizeChange;
+    let resizeChange: any = {};
     let yChange = resizeStartCoords.y - event.mouseY;
     let xChange = resizeStartCoords.x - event.mouseX;
 
-    switch (resizeDirection) {
+    switch (verticalDirection) {
 
         case 'n':
 
-          resizeChange = {
-            height: Math.max(this.minHeight, Math.min(initialStyle.height + yChange, initialStyle.height + initialStyle.top)),
-            width: initialStyle.width,
-            top: Math.max(0, initialStyle.top + (initialStyle.height + yChange <= this.minHeight ? (initialStyle.height - this.minHeight) : -yChange)),
-            left: initialStyle.left,
-          };
+          resizeChange.height = Math.max(this.minHeight, Math.min(initialStyle.height + yChange, initialStyle.height + initialStyle.top)),
+          resizeChange.top =  Math.max(0, initialStyle.top + (initialStyle.height + yChange <= this.minHeight ? (initialStyle.height - this.minHeight) : -yChange));
           break;
 
         case 's':
 
-          resizeChange = {
-            height: Math.max(this.minHeight, Math.min(initialStyle.height - yChange, this.workspaceDimensions.height - initialStyle.top)),
-            width: initialStyle.width,
-            top: initialStyle.top,
-            left: initialStyle.left,
-          };
+          resizeChange.height = Math.max(this.minHeight, Math.min(initialStyle.height - yChange, this.workspaceDimensions.height - initialStyle.top)),
+          resizeChange.top = initialStyle.top;
           break;
+
+        default:
+
+          resizeChange.height = initialStyle.height;
+          resizeChange.top = initialStyle.top;
+          break;
+    }
+
+    switch (horizontalDirection){
 
         case 'e':
 
-          resizeChange = {
-            height: initialStyle.height,
-            width: Math.max(this.minWidth, Math.min(initialStyle.width - xChange, this.workspaceDimensions.width - initialStyle.left)),
-            top: initialStyle.top,
-            left: initialStyle.left,
-          };
+          resizeChange.width = Math.max(this.minWidth, Math.min(initialStyle.width - xChange, this.workspaceDimensions.width - initialStyle.left)),
+          resizeChange.left = initialStyle.left;
           break;
 
         case 'w':
 
-          resizeChange = {
-            height: initialStyle.height,
-            width: Math.max(this.minWidth, Math.min(initialStyle.width + xChange, initialStyle.width + initialStyle.left)),
-            top: initialStyle.top,
-            left: Math.max(0, initialStyle.left - (initialStyle.width + xChange <= this.minWidth ? (initialStyle.width - this.minWidth) * -1 : xChange)),
-          };
+          resizeChange.width = Math.max(this.minWidth, Math.min(initialStyle.width + xChange, initialStyle.width + initialStyle.left));
+          resizeChange.left = Math.max(0, initialStyle.left - (initialStyle.width + xChange <= this.minWidth ? (initialStyle.width - this.minWidth) * -1 : xChange));
           break;
 
-        case 'nw':
-
-          resizeChange = {
-            height: Math.max(this.minHeight, Math.min(initialStyle.height + yChange, initialStyle.height + initialStyle.top)),
-            width: Math.max(this.minWidth, Math.min(initialStyle.width + xChange, initialStyle.width + initialStyle.left)),
-            top: Math.max(0, initialStyle.top + (initialStyle.height + yChange <= this.minHeight ? (initialStyle.height - this.minHeight) : -yChange)),
-            left: Math.max(0, initialStyle.left - (initialStyle.width + xChange <= this.minWidth ? (initialStyle.width - this.minWidth) * -1 : xChange)),
-          };
-          break;
-
-        case 'ne':
-
-          resizeChange = {
-            height: Math.max(this.minHeight, Math.min(initialStyle.height + yChange, initialStyle.height + initialStyle.top)),
-            width: Math.max(this.minWidth, Math.min(initialStyle.width - xChange, this.workspaceDimensions.width - initialStyle.left)),
-            top: Math.max(0, initialStyle.top + (initialStyle.height + yChange <= this.minHeight ? (initialStyle.height - this.minHeight) : -yChange)),
-            left: initialStyle.left,
-          };
-          break;
-
-        case 'se':
-
-          resizeChange = {
-            height: Math.max(this.minHeight, Math.min(initialStyle.height - yChange, this.workspaceDimensions.height - initialStyle.top)),
-            width: Math.max(this.minWidth, Math.min(initialStyle.width - xChange, this.workspaceDimensions.width - initialStyle.left)),
-            left: initialStyle.left,
-            top: initialStyle.top
-          };
-          break;
-
-        case 'sw':
-
-          resizeChange = {
-            height: Math.max(this.minHeight, Math.min(initialStyle.height - yChange, this.workspaceDimensions.height - initialStyle.top)),
-            width: Math.max(this.minWidth, Math.min(initialStyle.width + xChange, initialStyle.width + initialStyle.left)),
-            top: initialStyle.top,
-            left: Math.max(0, initialStyle.left - (initialStyle.width + xChange <= this.minWidth ? (initialStyle.width - this.minWidth) * -1 : xChange)),
-          };
-          break;
+        default:
+          resizeChange.width = initialStyle.width;
+          resizeChange.left = initialStyle.left;
     }
 
     this.setStyleByPixels(resizeChange);

--- a/src/app/workspace-panel/workspace-panel.component.ts
+++ b/src/app/workspace-panel/workspace-panel.component.ts
@@ -53,7 +53,6 @@ export class WorkspacePanelComponent implements OnInit {
 
   private draggingHeaderItem: boolean = false;
   private draggingPanel: boolean = false;
-  private resizing: boolean = false;
   private mouseMoveSub: Subscription;
   private mouseUpSub: Subscription;
 
@@ -207,7 +206,7 @@ export class WorkspacePanelComponent implements OnInit {
 
   onDrag(event) {
 
-    if (!this.draggingHeaderItem && !this.resizing && this.draggingPanel) {
+    if (!this.draggingHeaderItem && this.draggingPanel) {
 
       let transform: any = {};
       transform.y = event.y - this.pixelStyle.top - this.workspaceDimensions.top;
@@ -247,7 +246,7 @@ export class WorkspacePanelComponent implements OnInit {
 
   onDragStart(event) {
 
-    if (!this.resizing && !this.draggingPanel && !this.draggingHeaderItem) {
+    if (!this.draggingPanel && !this.draggingHeaderItem) {
       this.draggingPanel = true;
       this.setStyleByPixels(this.calculatePixelsStyle(this.relativeStyle));
     }

--- a/src/app/workspace-panel/workspace-panel.component.ts
+++ b/src/app/workspace-panel/workspace-panel.component.ts
@@ -215,15 +215,42 @@ export class WorkspacePanelComponent implements OnInit {
             left: initialStyle.left - (initialStyle.width + xChange <= this.minWidth ? (initialStyle.width - this.minWidth) * -1 : xChange),
           };
           break;
-        //
-        // case 'nw':
-        //   resizeChange = {
-        //     height: Math.max(this.minHeight, initialStyle.height + yChange),
-        //     width: Math.max(this.minWidth, initialStyle.width + xChange),
-        //     top: initialStyle.top + (initialStyle.height + yChange <= this.minHeight ? (initialStyle.height - this.minHeight) : -yChange),
-        //     left: initialStyle.left - (initialStyle.width + xChange <= this.minWidth ? (initialStyle.width - this.minWidth) * -1 : xChange),
-        //   }
-        //   break;
+
+        case 'nw':
+          resizeChange = {
+            height: Math.max(this.minHeight, initialStyle.height + yChange),
+            width: Math.max(this.minWidth, initialStyle.width - xChange),
+            top: initialStyle.top + (initialStyle.height + yChange <= this.minHeight ? (initialStyle.height - this.minHeight) : -yChange),
+            left: initialStyle.left - (initialStyle.width + xChange <= this.minWidth ? (initialStyle.width - this.minWidth) * -1 : xChange),
+          };
+          break;
+
+        case 'ne':
+          resizeChange = {
+            height: Math.max(this.minHeight, initialStyle.height + yChange),
+            width: Math.max(this.minWidth, initialStyle.width - xChange),
+            top: initialStyle.top + (initialStyle.height + yChange <= this.minHeight ? (initialStyle.height - this.minHeight) : -yChange),
+            left: initialStyle.left,
+          };
+          break;
+
+        case 'se':
+          resizeChange = {
+            height: Math.max(this.minHeight, initialStyle.height - yChange),
+            width: Math.max(this.minWidth, initialStyle.width - xChange),
+            left: initialStyle.left,
+            top: initialStyle.top
+          };
+          break;
+
+        case 'sw':
+          resizeChange = {
+            height: Math.max(this.minHeight, initialStyle.height - yChange),
+            width: Math.max(this.minWidth, initialStyle.width + xChange),
+            top: initialStyle.top,
+            left: initialStyle.left - (initialStyle.width + xChange <= this.minWidth ? (initialStyle.width - this.minWidth) * -1 : xChange)
+          };
+          break;
     }
 
     if (

--- a/src/app/workspace-panel/workspace-panel.component.ts
+++ b/src/app/workspace-panel/workspace-panel.component.ts
@@ -24,7 +24,16 @@ import { Subscription } from 'rxjs/Subscription';
   selector: 'workspace-panel',
   templateUrl: './workspace-panel.component.html',
   styleUrls: ['./workspace-panel.component.scss'],
-  entryComponents: [ChartComponent, NewsComponent, WatchlistComponent]
+  entryComponents: [ChartComponent, NewsComponent, WatchlistComponent],
+  host: {
+    '[style.height]': 'style.height',
+    '[style.width]': 'style.width',
+    '[style.left]': 'style.left',
+    '[style.top]': 'style.top',
+    '[style.minHeight]': 'minHeight',
+    '[style.minWidth]': 'minWidth',
+    '[style.transform]': 'transform'
+  }
 })
 export class WorkspacePanelComponent implements OnInit {
 
@@ -74,21 +83,6 @@ export class WorkspacePanelComponent implements OnInit {
     dragulaService.dragend.subscribe(event => {
       this.onFinishDragPanelHeader();
     });
-
-    this.validate = function(event: ResizeEvent){
-
-      if (
-        event.rectangle.top < this.workspaceDimensions.top ||
-        event.rectangle.left < 0 ||
-        event.rectangle.right > this.workspaceDimensions.width ||
-        event.rectangle.bottom > this.workspaceDimensions.bottom ||
-        event.rectangle.height < this.minHeight ||
-        event.rectangle.width < this.minWidth
-      ) {
-        return false;
-      }
-      return true;
-    }.bind(this);
   }
 
   // component: Class for the component you want to create
@@ -261,25 +255,6 @@ export class WorkspacePanelComponent implements OnInit {
 
     this.mouseMoveSub.unsubscribe();
     this.mouseUpSub.unsubscribe();
-    this.handlePanelChanged();
-  }
-
-  onResizeStart(event: ResizeEvent): void {
-
-    console.log('start resizing');
-    this.resizing = true;
-    this.draggingPanel = false;
-  }
-
-  onResizeEnd(event: ResizeEvent): void {
-
-    this.resizing = false;
-    this.setStyleByPixels({
-      left: event.rectangle.left,
-      top: event.rectangle.top - this.workspaceDimensions.top,
-      width: event.rectangle.width,
-      height: event.rectangle.height
-    });
     this.handlePanelChanged();
   }
 

--- a/src/app/workspace-panel/workspace-panel.component.ts
+++ b/src/app/workspace-panel/workspace-panel.component.ts
@@ -11,7 +11,6 @@ import {
   ReflectiveInjector,
   ComponentFactoryResolver
 } from '@angular/core';
-import { ResizeEvent } from 'angular2-resizable';
 import { DragulaService } from 'ng2-dragula';
 
 import { WatchlistComponent } from '../watchlist/watchlist.component';

--- a/src/app/workspace-panel/workspace-panel.component.ts
+++ b/src/app/workspace-panel/workspace-panel.component.ts
@@ -194,6 +194,24 @@ export class WorkspacePanelComponent implements OnInit {
             left: initialStyle.left,
           };
           break;
+
+        case 'e':
+          resizeChange = {
+            height: initialStyle.height,
+            width: initialStyle.width - xChange,
+            top: initialStyle.top,
+            left: initialStyle.left,
+          };
+          break;
+
+        case 'w':
+          resizeChange = {
+            height: initialStyle.height,
+            width: initialStyle.width + xChange,
+            top: initialStyle.top,
+            left: initialStyle.left - xChange,
+          };
+          break;
     }
     this.setStyleByPixels(resizeChange);
   }

--- a/src/app/workspace-panel/workspace-panel.component.ts
+++ b/src/app/workspace-panel/workspace-panel.component.ts
@@ -180,15 +180,15 @@ export class WorkspacePanelComponent implements OnInit {
         case 'n':
 
           resizeChange = {
-            height: initialStyle.height + yChange,
+            height: Math.max(this.minHeight, initialStyle.height + yChange),
             width: initialStyle.width,
-            top: initialStyle.top - yChange,
+            top: initialStyle.top + (initialStyle.height + yChange <= this.minHeight ? (initialStyle.height - this.minHeight) : -yChange),
             left: initialStyle.left,
           };
           break;
         case 's':
           resizeChange = {
-            height: initialStyle.height - yChange,
+            height: Math.max(this.minHeight, initialStyle.height - yChange),
             width: initialStyle.width,
             top: initialStyle.top,
             left: initialStyle.left,
@@ -198,7 +198,7 @@ export class WorkspacePanelComponent implements OnInit {
         case 'e':
           resizeChange = {
             height: initialStyle.height,
-            width: initialStyle.width - xChange,
+            width: Math.max(this.minWidth, initialStyle.width - xChange),
             top: initialStyle.top,
             left: initialStyle.left,
           };
@@ -207,9 +207,9 @@ export class WorkspacePanelComponent implements OnInit {
         case 'w':
           resizeChange = {
             height: initialStyle.height,
-            width: initialStyle.width + xChange,
+            width: Math.max(this.minWidth, initialStyle.width + xChange),
             top: initialStyle.top,
-            left: initialStyle.left - xChange,
+            left: initialStyle.left - (initialStyle.width + xChange <= this.minWidth ? (initialStyle.width - this.minWidth) * -1 : xChange),
           };
           break;
     }

--- a/src/app/workspace-panel/workspace-panel.component.ts
+++ b/src/app/workspace-panel/workspace-panel.component.ts
@@ -47,8 +47,6 @@ export class WorkspacePanelComponent implements OnInit {
   private mouseUpObs: Subject<any>;
   private mouseMoveSub: Subscription;
   private mouseUpSub: Subscription;
-  private resizeStartCoords: any;
-  private resizeDirection: string;
 
   style: any = {};
   transform: string;
@@ -156,27 +154,25 @@ export class WorkspacePanelComponent implements OnInit {
   resizeStart($event, direction) {
 
     this.setStyleByPixels(this.pixelStyle);
-    this.resizeDirection = direction;
+
     let resizeStartCoords = {
       x: $event.clientX,
       y: $event.clientY
     };
-
     let initialStyle = Object.assign({}, this.pixelStyle);
-    this.resizing = true;
-    this.mouseMoveSub = this.mouseMoveObs.subscribe(resizeEvent => this.resize(resizeEvent, resizeStartCoords, initialStyle));
+
+    this.mouseMoveSub = this.mouseMoveObs.subscribe(resizeEvent => this.resize(direction, resizeEvent, resizeStartCoords, initialStyle));
     this.mouseUpSub = this.mouseUpObs.subscribe(resizeEvent => this.resizeEnd(resizeEvent));
   }
 
-  resize(event, resizeStartCoords, initialStyle) {
-
-    console.log('initialStyle', initialStyle);
+  resize(resizeDirection, event, resizeStartCoords, initialStyle) {
 
     let resizeChange;
     let yChange = resizeStartCoords.y - event.mouseY;
     let xChange = resizeStartCoords.x - event.mouseX;
 
-    switch (this.resizeDirection) {
+    switch (resizeDirection) {
+
         case 'n':
 
           resizeChange = {
@@ -186,6 +182,7 @@ export class WorkspacePanelComponent implements OnInit {
             left: initialStyle.left,
           };
           break;
+
         case 's':
 
           resizeChange = {
@@ -217,6 +214,7 @@ export class WorkspacePanelComponent implements OnInit {
           break;
 
         case 'nw':
+
           resizeChange = {
             height: Math.max(this.minHeight, initialStyle.height + yChange),
             width: Math.max(this.minWidth, initialStyle.width - xChange),
@@ -226,6 +224,7 @@ export class WorkspacePanelComponent implements OnInit {
           break;
 
         case 'ne':
+
           resizeChange = {
             height: Math.max(this.minHeight, initialStyle.height + yChange),
             width: Math.max(this.minWidth, initialStyle.width - xChange),
@@ -235,6 +234,7 @@ export class WorkspacePanelComponent implements OnInit {
           break;
 
         case 'se':
+
           resizeChange = {
             height: Math.max(this.minHeight, initialStyle.height - yChange),
             width: Math.max(this.minWidth, initialStyle.width - xChange),
@@ -244,6 +244,7 @@ export class WorkspacePanelComponent implements OnInit {
           break;
 
         case 'sw':
+        
           resizeChange = {
             height: Math.max(this.minHeight, initialStyle.height - yChange),
             width: Math.max(this.minWidth, initialStyle.width + xChange),
@@ -270,13 +271,9 @@ export class WorkspacePanelComponent implements OnInit {
 
   resizeEnd(event) {
 
-    if (this.resizing) {
-      this.resizing = false;
-      this.resizeStartCoords = null;
-      this.mouseMoveSub.unsubscribe();
-      this.mouseUpSub.unsubscribe();
-      this.resizeDirection = '';
-    }
+    this.mouseMoveSub.unsubscribe();
+    this.mouseUpSub.unsubscribe();
+    this.handlePanelChanged();
   }
 
   onResizeStart(event: ResizeEvent): void {

--- a/src/app/workspace-panel/workspace-panel.component.ts
+++ b/src/app/workspace-panel/workspace-panel.component.ts
@@ -31,6 +31,8 @@ export class WorkspacePanelComponent implements OnInit {
   @Input() workspaceDimensions: ClientRect;
   @Input() initalConfig: any;
   @Input() order;
+  @Input() mouseMoveObs: Subject<any>;
+  @Input() mouseUpObs: Subject<any>;
 
   @Output() panelActive: EventEmitter<any> = new EventEmitter();
   @Output() panelChanged: EventEmitter<any> = new EventEmitter();
@@ -43,8 +45,6 @@ export class WorkspacePanelComponent implements OnInit {
   private draggingHeaderItem: boolean = false;
   private draggingPanel: boolean = false;
   private resizing: boolean = false;
-  private mouseMoveObs: Subject<any>;
-  private mouseUpObs: Subject<any>;
   private mouseMoveSub: Subscription;
   private mouseUpSub: Subscription;
 
@@ -67,8 +67,6 @@ export class WorkspacePanelComponent implements OnInit {
 
   constructor(private dragulaService: DragulaService, private resolver: ComponentFactoryResolver) {
 
-    this.mouseMoveObs = new Subject();
-    this.mouseUpObs = new Subject();
     dragulaService.drag.subscribe(event => {
       this.onDragPanelHeader(event.slice(1));
     });
@@ -139,16 +137,6 @@ export class WorkspacePanelComponent implements OnInit {
 
   onFinishDragPanelHeader() {
     this.draggingHeaderItem = false;
-  }
-
-  @HostListener('window:mousemove', ['$event.clientX', '$event.clientY'])
-  onResize(mouseX: number, mouseY: number): void {
-    this.mouseMoveObs.next({ mouseX, mouseY });
-  }
-
-  @HostListener('window:mouseup', ['$event'])
-  onMouseUp(event): void {
-    this.mouseUpObs.next(event);
   }
 
   resizeStart($event, direction) {
@@ -244,7 +232,7 @@ export class WorkspacePanelComponent implements OnInit {
           break;
 
         case 'sw':
-        
+
           resizeChange = {
             height: Math.max(this.minHeight, initialStyle.height - yChange),
             width: Math.max(this.minWidth, initialStyle.width + xChange),

--- a/src/app/workspace-panel/workspace-panel.component.ts
+++ b/src/app/workspace-panel/workspace-panel.component.ts
@@ -144,8 +144,8 @@ export class WorkspacePanelComponent implements OnInit {
     };
     let initialStyle = Object.assign({}, this.pixelStyle);
 
-    this.mouseMoveSub = this.mouseMoveObs.subscribe(resizeEvent => this.resize(horizontalDirection, verticalDirection, resizeEvent, resizeStartCoords, initialStyle));
-    this.mouseUpSub = this.mouseUpObs.subscribe(resizeEvent => this.resizeEnd(resizeEvent));
+    this.mouseMoveSub = this.mouseMoveObs.subscribe(event => this.resize(horizontalDirection, verticalDirection, event, resizeStartCoords, initialStyle));
+    this.mouseUpSub = this.mouseUpObs.subscribe(event => this.resizeEnd());
   }
 
   resize(horizontalDirection, verticalDirection, event, resizeStartCoords, initialStyle) {

--- a/src/app/workspace/workspace.component.html
+++ b/src/app/workspace/workspace.component.html
@@ -6,6 +6,8 @@
 <workspace-panel
   *ngFor="let config of workspacePanels"
   [workspaceDimensions]="dimensions"
+  [mouseMoveObs]="mouseMoveObs"
+  [mouseUpObs]="mouseUpObs"
   [initalConfig]="config"
   [order]="workspaceZIndexMap[config.id]"
   (panelActive)="updateActivePanel($event)"

--- a/src/app/workspace/workspace.component.ts
+++ b/src/app/workspace/workspace.component.ts
@@ -4,7 +4,6 @@ import { DragulaService } from 'ng2-dragula';
 import { Subject } from 'rxjs/Subject';
 
 import { WorkspaceService } from '../workspace.service';
-import { ResizableDirective } from '../resizable.directive';
 
 @Component({
   selector: 'workspace',

--- a/src/app/workspace/workspace.component.ts
+++ b/src/app/workspace/workspace.component.ts
@@ -1,6 +1,8 @@
 import { Component, OnInit, ElementRef, HostListener, Input, Output, EventEmitter } from '@angular/core';
 import { DragulaService } from 'ng2-dragula';
 
+import { Subject } from 'rxjs/Subject';
+
 import { WorkspaceService } from '../workspace.service';
 import { ResizableDirective } from '../resizable.directive';
 
@@ -18,6 +20,8 @@ export class WorkspaceComponent implements OnInit {
   workspacePanels: Array<any>;
   workspaceZIndexMap: any;
   dragulaBag = 'bag-one';
+  mouseMoveObs: Subject<any>;
+  mouseUpObs: Subject<any>;
 
   @Input() componentSelectorActive: boolean;
   @Output() componentAdded: EventEmitter<null> = new EventEmitter();
@@ -29,6 +33,8 @@ export class WorkspaceComponent implements OnInit {
   ) {
     this.workspacePanels = [];
     this.workspaceZIndexMap = {};
+    this.mouseMoveObs = new Subject();
+    this.mouseUpObs = new Subject();
   }
 
   ngOnInit() {
@@ -71,6 +77,16 @@ export class WorkspaceComponent implements OnInit {
   @HostListener('window:resize', ['$event'])
   onResize(event): void {
     this.setWorkspaceDimensions();
+  }
+
+  @HostListener('window:mousemove', ['$event.clientX', '$event.clientY'])
+  onMouseMove(mouseX: number, mouseY: number): void {
+    this.mouseMoveObs.next({ mouseX, mouseY });
+  }
+
+  @HostListener('window:mouseup', ['$event'])
+  onMouseUp(event): void {
+    this.mouseUpObs.next(event);
   }
 
   updateActivePanel(activePanel) {

--- a/src/app/workspace/workspace.component.ts
+++ b/src/app/workspace/workspace.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit, ElementRef, HostListener, Input, Output, EventEmitte
 import { DragulaService } from 'ng2-dragula';
 
 import { WorkspaceService } from '../workspace.service';
+import { ResizableDirective } from '../resizable.directive';
 
 @Component({
   selector: 'workspace',


### PR DESCRIPTION
The purpose of this PR is to create resizing logic for the new designs.

The way it works as that each 'panel' within a 'workspace' has 8 divs that act as resizing handles

n, ne, e, se, s, sw, w, nw

On mousedown on any of these div's, it subscribes to the mouse move event passing the panels initial state via a closure. It then calculates the panels size and position relative to mouse movement. It is bounded to the workspace.

Mousemove is bound once, and only ounce, and is injected into each panel.

On mouseup the subscription to mousemove is cancelled and the changes are saved.