### PR TITLE
Remove panel z index, use document ordering

### DIFF
--- a/src/app/workspace-panel/workspace-panel.component.ts
+++ b/src/app/workspace-panel/workspace-panel.component.ts
@@ -32,14 +32,12 @@ import { Subscription } from 'rxjs/Subscription';
     '[style.minHeight]': 'minHeight',
     '[style.minWidth]': 'minWidth',
     '[style.transform]': 'transform',
-    '[style.zIndex]': 'order'
   }
 })
 export class WorkspacePanelComponent implements OnInit {
 
   @Input() workspaceDimensions: ClientRect;
   @Input() initalConfig: any;
-  @Input() order;
   @Input() mouseMoveObs: Subject<any>;
   @Input() mouseUpObs: Subject<any>;
 
@@ -253,7 +251,7 @@ export class WorkspacePanelComponent implements OnInit {
   }
 
   setPanelActive() {
-    this.panelActive.emit({ panelId: this.panelId, order: this.order});
+    this.panelActive.emit({ panelId: this.panelId});
   }
 
   showComponent(componentId) {
@@ -347,7 +345,6 @@ export class WorkspacePanelComponent implements OnInit {
       },
       activeComponentId: this.activeComponentId,
       components: this.components,
-      order: this.order,
       id: this.panelId,
       active: 1
     })

--- a/src/app/workspace-panel/workspace-panel.component.ts
+++ b/src/app/workspace-panel/workspace-panel.component.ts
@@ -246,6 +246,7 @@ export class WorkspacePanelComponent implements OnInit {
 
     if (!this.draggingPanel && !this.draggingHeaderItem) {
       this.draggingPanel = true;
+      this.setPanelActive();
       this.setStyleByPixels(this.calculatePixelsStyle(this.relativeStyle));
     }
   }

--- a/src/app/workspace-panel/workspace-panel.component.ts
+++ b/src/app/workspace-panel/workspace-panel.component.ts
@@ -345,8 +345,7 @@ export class WorkspacePanelComponent implements OnInit {
       },
       activeComponentId: this.activeComponentId,
       components: this.components,
-      id: this.panelId,
-      active: 1
+      id: this.panelId
     })
   }
 }

--- a/src/app/workspace.service.ts
+++ b/src/app/workspace.service.ts
@@ -15,9 +15,7 @@ let defaultWorkspaceConfig = {
         top: 10,
         left: 10
       },
-      order: 3,
       id: 'panel1',
-      active: 1,
       activePanelId: 'firstComponent',
       components: [
         {
@@ -44,9 +42,7 @@ let defaultWorkspaceConfig = {
         top: 80,
         left: 70
       },
-      order: 2,
       id: 'panel2',
-      active: 0,
       components: [
         {
           header: 'Watchlist Component',
@@ -72,9 +68,7 @@ let defaultWorkspaceConfig = {
         top: 21,
         left: 11
       },
-      order: 1,
       id: 'panel3',
-      active: 0,
       components: [
         {
           header: 'Watchlist Component',

--- a/src/app/workspace/workspace.component.html
+++ b/src/app/workspace/workspace.component.html
@@ -4,7 +4,8 @@
 >
 </component-selector>
 <workspace-panel
-  *ngFor="let config of workspacePanels"
+  *ngFor="let config of workspacePanels; let i = index"
+  [ngClass]="{ 'active': i === workspacePanels.length - 1}"
   [workspaceDimensions]="dimensions"
   [mouseMoveObs]="mouseMoveObs"
   [mouseUpObs]="mouseUpObs"

--- a/src/app/workspace/workspace.component.html
+++ b/src/app/workspace/workspace.component.html
@@ -9,7 +9,6 @@
   [mouseMoveObs]="mouseMoveObs"
   [mouseUpObs]="mouseUpObs"
   [initalConfig]="config"
-  [order]="workspaceZIndexMap[config.id]"
   (panelActive)="updateActivePanel($event)"
   (panelChanged)="onWorkspacePanelChanged($event)"
   (panelDestroyed)="removeWorkspacePanel($event)"

--- a/src/app/workspace/workspace.component.ts
+++ b/src/app/workspace/workspace.component.ts
@@ -155,7 +155,6 @@ export class WorkspaceComponent implements OnInit {
   private createNewPanelWithCompoonent(component) {
 
     let panelId = 'panel-' + Math.random();
-    let zIndexOrder = this.workspacePanels.length + 1;
 
     this.workspacePanels.push({
       dimensions: {
@@ -164,9 +163,7 @@ export class WorkspaceComponent implements OnInit {
         top: 20,
         left: 20
       },
-      order: zIndexOrder,
       id: panelId,
-      active: 0,
       components: [
         component
       ]

--- a/src/app/workspace/workspace.component.ts
+++ b/src/app/workspace/workspace.component.ts
@@ -17,7 +17,6 @@ export class WorkspaceComponent implements OnInit {
   private activeWorkspace: any;
 
   workspacePanels: Array<any>;
-  workspaceZIndexMap: any;
   dragulaBag = 'bag-one';
   mouseMoveObs: Subject<any>;
   mouseUpObs: Subject<any>;
@@ -31,7 +30,6 @@ export class WorkspaceComponent implements OnInit {
     private dragulaService: DragulaService
   ) {
     this.workspacePanels = [];
-    this.workspaceZIndexMap = {};
     this.mouseMoveObs = new Subject();
     this.mouseUpObs = new Subject();
   }
@@ -90,18 +88,14 @@ export class WorkspaceComponent implements OnInit {
 
   updateActivePanel(activePanel) {
 
-    if (this.activePanel !== activePanel.panelId) {
+    this.workspacePanels.sort((a,b) => {
 
-      this.activePanel = activePanel.panelId;
-      Object.keys(this.workspaceZIndexMap).forEach(panelKey => {
-
-        if (panelKey === activePanel.panelId) {
-          this.workspaceZIndexMap[panelKey] = this.workspacePanels.length;
-        } else if (this.workspaceZIndexMap[panelKey] >= activePanel.order) {
-          --this.workspaceZIndexMap[panelKey]
-        }
-      });
-    }
+      if (a.id === activePanel.panelId) {
+        return 1;
+      } else {
+        return 0;
+      }
+    });
   }
 
   removeWorkspacePanel(panelId) {
@@ -113,7 +107,6 @@ export class WorkspaceComponent implements OnInit {
 
   changeWorkspace(workspaceConfig) {
 
-    this.activePanel = null;
     this.workspacePanels = [];
     this.activeWorkspace = null;
     this.initalizeWorkspacePanels(workspaceConfig);
@@ -138,13 +131,6 @@ export class WorkspaceComponent implements OnInit {
 
     this.activeWorkspace = workspaceConfig;
     this.workspacePanels = workspaceConfig.panels;
-    this.workspacePanels.forEach(panel => {
-      this.workspaceZIndexMap[panel.id] = panel.order;
-
-      if (panel.active){
-        this.activePanel = panel.id;
-      }
-    });
   }
 
   private onWorkspacePanelChanged(panelChanged): void {
@@ -186,7 +172,6 @@ export class WorkspaceComponent implements OnInit {
       ]
     });
 
-    this.workspaceZIndexMap[panelId] = zIndexOrder;
     this.saveActiveWorkspace();
   }
 

--- a/src/app/workspace/workspace.component.ts
+++ b/src/app/workspace/workspace.component.ts
@@ -96,6 +96,7 @@ export class WorkspaceComponent implements OnInit {
         return 0;
       }
     });
+    this.saveActiveWorkspace();
   }
 
   removeWorkspacePanel(panelId) {


### PR DESCRIPTION
This was a suggestion from Shavin about how to handle z index order for panels in a workspace.

Rather than explicitly setting the z index of the panel, when a panel becomes active we sort the components array so that the active panel is always the last item the panels array in the workspace, which means the ngFor directive moves it to end of the panels html mark up, thereby showing on top of the other.